### PR TITLE
fix: SHA-pin all 3rd-party GitHub Actions (supply chain hardening)

### DIFF
--- a/.github/workflows/firefly-cache-manager.yaml
+++ b/.github/workflows/firefly-cache-manager.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   call-build-cache:
-    uses: infralight/.github/.github/workflows/golang-cache-manager.yaml@master
+    uses: infralight/.github/.github/workflows/golang-cache-manager.yaml@5a6cb3462fa8ca2fb0a7564a03f5f6c475fa6306 # master
     with:
       branch: ${{ inputs.branch || 'main' }}
       app-name: ${{ inputs.app-name || '*' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,6 @@ jobs:
           version: v3.8.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0     
+        uses: helm/chart-releaser-action@fc23f249f75decd5edf254c6b4401532cef093c3 # v1.4.0     
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release_cloudformation.yml
+++ b/.github/workflows/release_cloudformation.yml
@@ -18,7 +18,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.CI_AWS_CRED_SECRET }}
         aws-region: ${{ secrets.CI_REGION }}
     - name: Upload ECS Cloudformation Template
-      uses: jakejarvis/s3-sync-action@master
+      uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311 # master
       with:
         args: --acl public-read --follow-symlinks --exclude='*' --include='template.yml'
       env:

--- a/.github/workflows/release_terraform.yaml
+++ b/.github/workflows/release_terraform.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Bump version and push tag
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.0
+        uses: mathieudutour/github-tag-action@06382dcd483ebaea54d37e40ad576658a6c6ef73 # v6.0
         with:
           release_branches: main
           github_token: ${{ github.token }}
@@ -36,7 +36,7 @@ jobs:
       - name: Bump beta version and push tag
         if: github.event_name == 'workflow_dispatch'
         id: tag_version_branch
-        uses: mathieudutour/github-tag-action@v6.0
+        uses: mathieudutour/github-tag-action@06382dcd483ebaea54d37e40ad576658a6c6ef73 # v6.0
         with:
           pre_release_branches: .*
           github_token: ${{ github.token }}


### PR DESCRIPTION
## Summary
Pin all 3rd-party action references to immutable SHA digests.

## Why
Mutable tags can be force-pushed by attackers to point at malicious commits (as happened with aquasecurity/trivy-action on 2026-03-19). SHA-pinned references are immutable and safe from this class of attack.

No functional changes -- all SHAs resolve to the same versions previously referenced by tag.